### PR TITLE
WEB-4145 : Restrict permissions to Plone rest api

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@ Changelog
 1.1.4 (unreleased)
 ------------------
 
+- WEB-4145 : Restrict permissions to Plone rest api
+  [boulch]
+
 - GHA tests on Python 3.8 3.9 and 3.10
   [remdub]
 

--- a/src/imio/directory/policy/permissions.zcml
+++ b/src/imio/directory/policy/permissions.zcml
@@ -5,8 +5,6 @@
 
   <configure zcml:condition="installed AccessControl.security">
   <!-- -*- extra stuff goes here -*- -->
-
-
   </configure>
 
 </configure>

--- a/src/imio/directory/policy/profiles/default/metadata.xml
+++ b/src/imio/directory/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1004</version>
+  <version>1005</version>
   <dependencies>
     <dependency>profile-plone.app.contenttypes:plone-content</dependency>
     <dependency>profile-plone.restapi:default</dependency>

--- a/src/imio/directory/policy/profiles/default/rolemap.xml
+++ b/src/imio/directory/policy/profiles/default/rolemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+
+    <permission name="plone.restapi: Use REST API" acquire="True">
+        <role name="Manager" />
+    </permission>
+
+  </permissions>
+</rolemap>

--- a/src/imio/directory/policy/upgrades/configure.zcml
+++ b/src/imio/directory/policy/upgrades/configure.zcml
@@ -27,6 +27,14 @@
     provides="Products.GenericSetup.interfaces.EXTENSION"
   />
 
+  <genericsetup:registerProfile
+    name="upgrade_1004_to_1005"
+    title="Upgrade policy from 1004 to 1005"
+    directory="profiles/1004_to_1005"
+    description="Restrict permissions to Plone rest api"
+    provides="Products.GenericSetup.interfaces.EXTENSION"
+  />  
+  
   <genericsetup:upgradeSteps
       source="1000"
       destination="1001"
@@ -73,5 +81,18 @@
         import_steps="actions"
         />
   </genericsetup:upgradeSteps>
+
+
+  <genericsetup:upgradeSteps
+      source="1004"
+      destination="1005"
+      profile="imio.directory.policy:default">
+    <genericsetup:upgradeDepends
+        title="Restrict permissions to Plone rest api"
+        import_profile="imio.directory.policy.upgrades:upgrade_1004_to_1005"
+        import_steps="rolemap"
+        />
+  </genericsetup:upgradeSteps>
+
 
 </configure>

--- a/src/imio/directory/policy/upgrades/profiles/1004_to_1005/rolemap.xml
+++ b/src/imio/directory/policy/upgrades/profiles/1004_to_1005/rolemap.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<rolemap>
+  <permissions>
+
+    <permission name="plone.restapi: Use REST API" acquire="True">
+        <role name="Manager" />
+    </permission>
+
+  </permissions>
+</rolemap>


### PR DESCRIPTION
@laulaz 
There is long time ago... far far away... We had mentioned that we would limit access to the REST API of authentic sources.
My question is : is it enough or is it too penalizing to proceed in this way to limit access to the rest-api?
Tests will follow...